### PR TITLE
Open --downscale parameter to increase speed

### DIFF
--- a/tools/demo.py
+++ b/tools/demo.py
@@ -52,7 +52,7 @@ def make_parser():
 
     # CMC
     parser.add_argument("--cmc-method", default="orb", type=str, help="cmc method: files (Vidstab GMC) | orb | ecc")
-    parser.add_argument("--downscale", default=2, type=int, help="cmc downscale, large image leads to very slow gmc, increase diwnscale to increase speed")
+    parser.add_argument("--downscale", default=2, type=int, help="cmc downscale, large image leads to very slow gmc, increase downscale to increase speed")
 
     # ReID
     parser.add_argument("--with-reid", dest="with_reid", default=False, action="store_true", help="test mot20.")

--- a/tools/demo.py
+++ b/tools/demo.py
@@ -52,6 +52,7 @@ def make_parser():
 
     # CMC
     parser.add_argument("--cmc-method", default="orb", type=str, help="cmc method: files (Vidstab GMC) | orb | ecc")
+    parser.add_argument("--downscale", default=2, type=int, help="cmc downscale, large image leads to very slow gmc, increase diwnscale to increase speed")
 
     # ReID
     parser.add_argument("--with-reid", dest="with_reid", default=False, action="store_true", help="test mot20.")

--- a/tracker/bot_sort.py
+++ b/tracker/bot_sort.py
@@ -225,7 +225,7 @@ class BoTSORT(object):
         if args.with_reid:
             self.encoder = FastReIDInterface(args.fast_reid_config, args.fast_reid_weights, args.device)
 
-        self.gmc = GMC(method=args.cmc_method, verbose=[args.name, args.ablation])
+        self.gmc = GMC(method=args.cmc_method, downscale=args.downscale, verbose=[args.name, args.ablation])
 
     def update(self, output_results, img):
         self.frame_id += 1


### PR DESCRIPTION
Large image leads to very slow GMC. GMC of a (768, 1280) image takes about unbearable 3.6s. Thus open --downscale parameter to increase speed.