### PR TITLE
Numpy version deprecated 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ wandb/
 fast_reid/datasets/MOT17-ReID
 */__pycache__
 *.so
+videos/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<1.24
 opencv-python
 loguru
 scikit-image
@@ -26,5 +26,5 @@ gdown
 onnx==1.8.1
 onnxruntime==1.8.0
 onnx-simplifier==0.3.5
-
+faiss-cpu
 


### PR DESCRIPTION
https://github.com/NirAharon/BoT-SORT/blob/251985436d6712aaf682aaaf5f71edb4987224bd/tracker/matching.py#L65

Please check for the deprecated functions in the `numpy==1.24.0` version, `np.float` is deprecated and is now used as `np.flaot32` or `np.flaot64`. Installing `numpy<1.24` does the work, but in the future, the `cythin_bbox` module has to be also looked into for this.